### PR TITLE
Add pip to conda dependencies

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -5,5 +5,6 @@ dependencies:
   - numpy=1.14.3
   - pandas=0.22.0
   - scikit-learn=0.19.1
+  - pip
   - pip:
     - mlflow


### PR DESCRIPTION
If pip isn't explicitly mentioned in conda.yaml it will default to the system pip. This broke the example for me as i had an out of date version of pip which didn't work with the latest conda.