### PR TITLE
Update minimum Pandas version

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@ channels:
   - defaults
 dependencies:
   - numpy=1.14.3
-  - pandas=0.22.0
+  - pandas=1.0.4
   - scikit-learn=0.19.1
   - pip:
     - mlflow

--- a/conda.yaml
+++ b/conda.yaml
@@ -2,7 +2,7 @@ name: tutorial
 channels:
   - defaults
 dependencies:
-  - numpy=1.14.3
+  - numpy>=1.14.3
   - pandas>=1.0.0
   - scikit-learn=0.19.1
   - pip:

--- a/conda.yaml
+++ b/conda.yaml
@@ -3,7 +3,7 @@ channels:
   - defaults
 dependencies:
   - numpy=1.14.3
-  - pandas=1.0.4
+  - pandas>=1.0.0
   - scikit-learn=0.19.1
   - pip:
     - mlflow


### PR DESCRIPTION
When we added support for Model Schemas to MLflow, a later version of Pandas than the one specified in this example became a hard dependency. Accordingly, this PR updates the version of Pandas in this example to fix the following Pandas module import error (this module did not exist in `0.22`):

```
Traceback (most recent call last):
  File "train.py", line 15, in <module>
    import mlflow
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/__init__.py", line 31, in <module>
    import mlflow.tracking._model_registry.fluent
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/tracking/__init__.py", line 8, in <module>
    from mlflow.tracking.client import MlflowClient
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/tracking/client.py", line 13, in <module>
    from mlflow.tracking._model_registry.client import ModelRegistryClient
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/tracking/_model_registry/client.py", line 10, in <module>
    from mlflow.tracking._model_registry import utils
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/tracking/_model_registry/utils.py", line 4, in <module>
    from mlflow.store.model_registry.rest_store import RestStore
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/store/model_registry/rest_store.py", line 12, in <module>
    from mlflow.utils.proto_json_utils import message_to_json
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/utils/proto_json_utils.py", line 9, in <module>
    from mlflow.types import DataType
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/types/__init__.py", line 6, in <module>
    from .schema import DataType, ColSpec, Schema
  File "/Users/czumar/anaconda2/envs/mlflow-3eee9bd7a0713cf80a17bc0a4d659bc9c549efac/lib/python3.6/site-packages/mlflow/types/schema.py", line 8, in <module>
    from pandas.core.dtypes.dtypes import PandasExtensionDtype
ImportError: cannot import name 'PandasExtensionDtype'
2020/06/19 13:28:34 ERROR mlflow.cli: === Run (ID 'b90863901bce4868bc47576fb73e7aeb') failed ===

```